### PR TITLE
Added OS X Pod Platform (closes #11)

### DIFF
--- a/KiteJSONValidator.podspec
+++ b/KiteJSONValidator.podspec
@@ -17,7 +17,8 @@ Pod::Spec.new do |s|
   s.authors       = { "Sam Duke" => "samskiter@users.noreply.github.com" }
   s.version      = "0.2.2"
   s.source       = { :git => "https://github.com/samskiter/KiteJSONValidator.git", :tag => "v#{s.version}"}
-  s.platform     = :ios, '7.0'
+  s.ios.deployment_target = '7.0'
+  s.osx.deployment_target = '10.9'
   s.requires_arc = true
   s.source_files = "Sources/*.{h,m}"
   s.xcconfig     = {


### PR DESCRIPTION
The change to the podspec should allow use of the library for both OSX and iOS.  I have tested it on project of mine already and everything appears to be working fine.

Relevant documentation for you: http://guides.cocoapods.org/syntax/podspec.html#platform